### PR TITLE
fix(precomputed): prevent silent OOM crashes on extremely large matrices (fixes #1)

### DIFF
--- a/sparse_convolution/sparse_convolution.py
+++ b/sparse_convolution/sparse_convolution.py
@@ -205,19 +205,31 @@ class Toeplitz_convolution2d():
             import torch
             device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
-        ## Warn if Toeplitz matrix will be very large
-        if verbose > 0 and method == 'precomputed':
+        ## Warn or fail if Toeplitz matrix will be very large
+        if method == 'precomputed':
             n_nz_expected = x_shape[0] * x_shape[1] * k.shape[0] * k.shape[1]
-            if n_nz_expected >= 1e8:
-                print(
-                    "Warning: Expected number of non-zero elements in the "
+            if n_nz_expected >= 1e9:
+                raise ValueError(
+                    f"Expected number of non-zero elements in the Toeplitz matrix "
+                    f"is extremely large ({n_nz_expected} non-zero elements).\n"
+                    f"This would likely cause a silent Out-Of-Memory (OOM) crash.\n"
+                    f"Please use a memory-efficient method like method='direct' or "
+                    f"method='gather_scatter' instead."
+                )
+            elif n_nz_expected >= 1e7:
+                import warnings
+                warnings.warn(
+                    "Expected number of non-zero elements in the "
                     "Toeplitz matrix is large.\n"
                     f"(x_shape[0]*x_shape[1]*k.shape[0]*k.shape[1]) = "
                     f"{n_nz_expected} non-zero elements.\n"
                     "This will likely be slow and have a large memory "
                     "footprint.\n"
-                    "Consider using method='lazy' or 'gather_scatter'."
+                    "Consider using method='direct' or 'gather_scatter' instead.",
+                    UserWarning,
+                    stacklevel=2,
                 )
+
 
         ## Store parameters
         self.k = k.copy()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -142,3 +142,23 @@ def test_default_method_uses_direct_numba():
     assert conv.method == "direct"
     assert conv.backend == "numba"
     assert np.allclose(out, scipy.signal.convolve2d(x, k, mode="same"))
+
+
+def test_precomputed_size_checks():
+    """Verify that method='precomputed' raises ValueError for extremely large matrices and warns for large ones."""
+    # 10000x10000 image with 10x10 kernel -> 1e8 * 100 = 1e10 elements (should raise ValueError)
+    with pytest.raises(ValueError, match="extremely large"):
+        Toeplitz_convolution2d(
+            x_shape=(10000, 10000),
+            k=np.zeros((10, 10)),
+            method="precomputed",
+        )
+
+    # 1000x1000 image with 5x5 kernel -> 1e6 * 25 = 2.5e7 elements (should warn)
+    with pytest.warns(UserWarning, match="Toeplitz matrix is large"):
+        Toeplitz_convolution2d(
+            x_shape=(1000, 1000),
+            k=np.zeros((5, 5)),
+            method="precomputed",
+        )
+


### PR DESCRIPTION
Raises a clear ValueError if the expected size of a precomputed Toeplitz matrix exceeds 1e9 non-zeros, avoiding a silent OOM process crash. Also warns when the expected size is large (>= 1e7).