### PR TITLE
docs: add matrix size limitation to README (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ conv = sc.Toeplitz_convolution2d(
 
 If `backend=None` (default), `direct` uses `numba`. For environments without numba, choose a numpy-capable method explicitly, such as `method='gather_scatter', backend='numpy'` or `method='precomputed', backend='numpy'`.
 
+
+## Limitations
+
+The convolution is optimized for input matrices smaller than **(1000, 1000)**. For larger matrices, the Toeplitz construction may become memory-intensive or fail silently. If you need to process larger inputs, consider tiling them into smaller patches before applying sparse convolution.
+
 ## References
 - Toeplitz convolution: [stackoverflow.com/a/51865516](https://stackoverflow.com/a/51865516), [alisaaalehi/convolution_as_multiplication](https://github.com/alisaaalehi/convolution_as_multiplication)
 - 1D convolution matrix: [scipy.linalg.convolution_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.convolution_matrix.html)


### PR DESCRIPTION
## What

Documents the (1000, 1000) matrix size limitation in the README, as requested in #1.

## Changes

Added a `Limitations` section to the README noting that the convolution is optimized for inputs smaller than 1000x1000 and may become memory-intensive or fail silently for larger matrices. Suggests tiling as a workaround.

Closes #1