### PR TITLE
docs: add matrix size guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Sparse 2D convolution in Python via Toeplitz matrix methods.
 
 Fast when the kernel is small, the input is sparse, and/or many arrays share the same kernel.
+Ideal with matrices smaller than ~(1000, 1000). For larger matrices the Toeplitz construction can become memory-intensive.
 
 ## Install
 ```


### PR DESCRIPTION
Closes #1

Adds a note in the README that the implementation is ideal for matrices smaller than ~(1000, 1000), as the Toeplitz construction can become memory-intensive for larger inputs.

**Related issue:** [#1](https://github.com/RichieHakim/sparse_convolution/issues/1)